### PR TITLE
Make Result public to facilitate implementation of FluentValidator trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub enum Error {
     InvalidSize(String),
 }
 
-type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 pub trait Validator<T> {
     fn validate(T) -> Result<T>;


### PR DESCRIPTION
Suggest to make 'Result' type public so that it is easier to implement FluentValidator's trait